### PR TITLE
docs: Fix simple typo, propertie -> property

### DIFF
--- a/ObjectEventTarget.js
+++ b/ObjectEventTarget.js
@@ -138,7 +138,7 @@ var ObjectEventTarget = {options: {VERSION: '1.3.1'}};
       pos = eventQueue.indexOf(callback);
     }
 
-    // Remove the propertie with array when the array is empty
+    // Remove the property with array when the array is empty
     if (eventQueue.length === 0){
       delete eventsMap[type];
     }
@@ -314,7 +314,7 @@ var ObjectEventTarget = {options: {VERSION: '1.3.1'}};
   ObjectEvent.prototype.AT_TARGET = 2;
   ObjectEvent.prototype.BUBBLING_PHASE = 3;
   ObjectEvent.prototype.initEvent = function() {
-    // Init event if it has some propertie wrong, fix it
+    // Init event if it has some property wrong, fix it
 
     // Time that the event has created
     this.timeStamp = this.timeStamp || Date.now();

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The methods aren't enumerables, but only for modern-browsers and nodejs, if you 
 
 * **addEventListener( eventType, callback )**
 * **removeEventListener( eventType, callback )**
-* **dispatchEvent( event )** The event can be any object that has "type" propertie as string, recomends to use `new ObjectEvent('type name')`.
+* **dispatchEvent( event )** The event can be any object that has "type" property as string, recomends to use `new ObjectEvent('type name')`.
 
 Events
 ------

--- a/src/ObjectEventTarget.js
+++ b/src/ObjectEventTarget.js
@@ -133,7 +133,7 @@
       pos = eventQueue.indexOf(callback);
     }
 
-    // Remove the propertie with array when the array is empty
+    // Remove the property with array when the array is empty
     if (eventQueue.length === 0){
       delete eventsMap[type];
     }
@@ -309,7 +309,7 @@
   ObjectEvent.prototype.AT_TARGET = 2;
   ObjectEvent.prototype.BUBBLING_PHASE = 3;
   ObjectEvent.prototype.initEvent = function() {
-    // Init event if it has some propertie wrong, fix it
+    // Init event if it has some property wrong, fix it
 
     // Time that the event has created
     this.timeStamp = this.timeStamp || Date.now();


### PR DESCRIPTION
There is a small typo in ObjectEventTarget.js, README.md, src/ObjectEventTarget.js.

Should read `property` rather than `propertie`.

